### PR TITLE
Feat: Add Classifier Tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from models import (
     EndSessionResponse,
     GenerateReportRequest,
     GenerateReportResponse,
+    PatchReportRequest,
     GuidanceLevel,
     PostLabCheckRequest,
     PostLabCheckResponse,
@@ -445,3 +446,20 @@ async def get_report(
     if report is None:
         raise HTTPException(status_code=404, detail="Report not found.")
     return report
+
+
+@app.patch(
+    "/report/{report_id}",
+    tags=["reports"],
+    dependencies=[Depends(verify_internal_token)],
+)
+async def patch_report(
+    report_id: str,
+    body: PatchReportRequest,
+    cosmos: CosmosIntegrityClient = Depends(get_cosmos),
+) -> dict:
+    report = await cosmos.get_report(report_id, body.student_id)
+    if report is None:
+        raise HTTPException(status_code=404, detail="Report not found.")
+    report["instructor_notes"] = body.instructor_notes
+    return await cosmos.upsert_report(report)

--- a/cosmos_client.py
+++ b/cosmos_client.py
@@ -107,6 +107,11 @@ class CosmosIntegrityClient:
         except cosmos_exceptions.CosmosResourceNotFoundError:
             return None
 
+    async def upsert_report(self, doc: dict) -> dict:
+        """Insert or replace a report document."""
+        result = await self._reports.upsert_item(body=doc)
+        return result
+
     async def get_reports_for_session(
         self, session_id: str, student_id: str
     ) -> list[dict]:

--- a/cosmos_client_memory.py
+++ b/cosmos_client_memory.py
@@ -66,6 +66,10 @@ class MemoryIntegrityClient:
     async def get_report(self, report_id: str, student_id: str) -> Optional[dict]:
         return self._reports.get(report_id)
 
+    async def upsert_report(self, doc: dict) -> dict:
+        self._reports[doc["id"]] = doc
+        return doc
+
     async def get_reports_for_session(
         self, session_id: str, student_id: str
     ) -> list[dict]:

--- a/cosmos_client_memory.py
+++ b/cosmos_client_memory.py
@@ -37,7 +37,10 @@ class MemoryIntegrityClient:
         return doc
 
     async def get_session(self, session_id: str, student_id: str) -> Optional[dict]:
-        return self._sessions.get(session_id)
+        session = self._sessions.get(session_id)
+        if session is None or session.get("student_id") != student_id:
+            return None
+        return session
 
     async def upsert_session(self, doc: dict) -> dict:
         self._sessions[doc["id"]] = doc
@@ -64,7 +67,10 @@ class MemoryIntegrityClient:
         return doc
 
     async def get_report(self, report_id: str, student_id: str) -> Optional[dict]:
-        return self._reports.get(report_id)
+        report = self._reports.get(report_id)
+        if report is None or report.get("student_id") != student_id:
+            return None
+        return report
 
     async def upsert_report(self, doc: dict) -> dict:
         self._reports[doc["id"]] = doc

--- a/models.py
+++ b/models.py
@@ -116,6 +116,11 @@ class GenerateReportResponse(BaseModel):
     report: dict
 
 
+class PatchReportRequest(BaseModel):
+    student_id: str
+    instructor_notes: dict
+
+
 class PostLabCheckRequest(BaseModel):
     student_id: str
     session_ids: list[str]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pydantic>=2.0.0,<3
 pydantic-settings>=2.0.0,<3
 httpx>=0.27.0,<1
 pytest>=8.0.0,<9
+pytest-asyncio>=0.23.0,<1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ azure-core>=1.37.0,<2
 python-dotenv>=1.2.1,<2
 pydantic>=2.0.0,<3
 pydantic-settings>=2.0.0,<3
+httpx>=0.27.0,<1
+pytest>=8.0.0,<9

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,7 +1,8 @@
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
+from openai import RateLimitError
 
 from models import GuidanceLevel, QuestionClassification
 from policy_engine import ClassificationResult, classify_question
@@ -113,3 +114,71 @@ async def test_malformed_json_raises():
             openai_client=client,
             deployment_name="fake-deployment",
         )
+
+
+# ---------------------------------------------------------------------------
+# RateLimitError and generic exception propagation
+# ---------------------------------------------------------------------------
+
+async def test_rate_limit_error_propagates():
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(
+        side_effect=RateLimitError(
+            message="rate limit exceeded",
+            response=MagicMock(status_code=429, headers={}),
+            body={},
+        )
+    )
+    with pytest.raises(RateLimitError):
+        await classify_question(
+            question_text="test",
+            conversation_history=[],
+            session_context=SESSION_CONTEXT,
+            openai_client=client,
+            deployment_name="fake-deployment",
+        )
+
+
+async def test_generic_exception_propagates():
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=ConnectionError("network failure"))
+    with pytest.raises(ConnectionError):
+        await classify_question(
+            question_text="test",
+            conversation_history=[],
+            session_context=SESSION_CONTEXT,
+            openai_client=client,
+            deployment_name="fake-deployment",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Conversation history trimming — only last 6 turns sent to OpenAI
+# ---------------------------------------------------------------------------
+
+async def test_conversation_history_trimmed_to_last_6_turns():
+    client = _make_openai_mock("CONCEPTUAL", "FULL")
+
+    history = [
+        {"role": "user",      "content": f"question {i}"}
+        for i in range(10)  # 10 turns, only last 6 should be sent
+    ]
+
+    await classify_question(
+        question_text="test",
+        conversation_history=history,
+        session_context=SESSION_CONTEXT,
+        openai_client=client,
+        deployment_name="fake-deployment",
+    )
+
+    # Extract the user message content that was sent to OpenAI
+    sent_content = client.chat.completions.create.call_args[1]["messages"][1]["content"]
+
+    # Last 6 turns are "question 4" through "question 9"
+    for i in range(4, 10):
+        assert f"question {i}" in sent_content
+
+    # First 4 turns should have been trimmed
+    for i in range(0, 4):
+        assert f"question {i}" not in sent_content

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,115 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models import GuidanceLevel, QuestionClassification
+from policy_engine import ClassificationResult, classify_question
+
+SESSION_CONTEXT = {"lab_id": "lab01", "question_count": 3, "violation_count": 0}
+
+
+def _make_openai_mock(classification: str, guidance: str, message: str | None = None) -> MagicMock:
+    payload = json.dumps({
+        "classification": classification,
+        "confidence": 0.99,
+        "reasoning": "mocked",
+        "recommended_guidance": guidance,
+        "student_facing_message": message,
+    })
+    mock_msg = MagicMock()
+    mock_msg.content = payload
+    mock_choice = MagicMock()
+    mock_choice.message = mock_msg
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=mock_response)
+    return client
+
+
+def _make_malformed_mock(raw: str) -> MagicMock:
+    mock_msg = MagicMock()
+    mock_msg.content = raw
+    mock_choice = MagicMock()
+    mock_choice.message = mock_msg
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=mock_response)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# All 5 classification types
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("classification,guidance", [
+    ("CONCEPTUAL",      "FULL"),
+    ("PROCEDURAL",      "MODERATE"),
+    ("CLARIFICATION",   "FULL"),
+    ("DIRECT_SOLUTION", "REJECTED"),
+    ("ANSWER_FARMING",  "MINIMAL"),
+])
+async def test_classify_all_types(classification, guidance):
+    client = _make_openai_mock(classification, guidance)
+    result = await classify_question(
+        question_text="test question",
+        conversation_history=[],
+        session_context=SESSION_CONTEXT,
+        openai_client=client,
+        deployment_name="fake-deployment",
+    )
+    assert result.classification == QuestionClassification(classification)
+    assert result.recommended_guidance == GuidanceLevel(guidance)
+    assert result.confidence == 0.99
+    assert result.reasoning == "mocked"
+
+
+# ---------------------------------------------------------------------------
+# student_facing_message present vs null
+# ---------------------------------------------------------------------------
+
+async def test_student_facing_message_present():
+    client = _make_openai_mock("DIRECT_SOLUTION", "REJECTED", "No direct solutions.")
+    result = await classify_question(
+        question_text="Give me the answer",
+        conversation_history=[],
+        session_context=SESSION_CONTEXT,
+        openai_client=client,
+        deployment_name="fake-deployment",
+    )
+    assert result.student_facing_message == "No direct solutions."
+
+
+async def test_student_facing_message_null():
+    client = _make_openai_mock("CONCEPTUAL", "FULL", message=None)
+    result = await classify_question(
+        question_text="What is impedance matching?",
+        conversation_history=[],
+        session_context=SESSION_CONTEXT,
+        openai_client=client,
+        deployment_name="fake-deployment",
+    )
+    assert result.student_facing_message is None
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON response
+#
+# classify_question() calls json.loads() with no try/except — a malformed
+# response raises json.JSONDecodeError. This is intentional: app.py's
+# /validate endpoint wraps classify_question() in a broad except clause
+# that applies a MODERATE fail-safe, so the error is handled upstream.
+# ---------------------------------------------------------------------------
+
+async def test_malformed_json_raises():
+    client = _make_malformed_mock("not valid json {{{")
+    with pytest.raises(json.JSONDecodeError):
+        await classify_question(
+            question_text="test",
+            conversation_history=[],
+            session_context=SESSION_CONTEXT,
+            openai_client=client,
+            deployment_name="fake-deployment",
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,108 @@
+import os
+os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://fake.openai.azure.com/")
+os.environ.setdefault("AZURE_OPENAI_API_KEY", "fake-key")
+os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT_NAME", "fake-deployment")
+os.environ.setdefault("USE_MEMORY_STORE", "true")
+os.environ.setdefault("INTERNAL_API_TOKEN", "demo-token")
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from app import app, get_openai
+
+HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
+
+
+def _make_openai_mock(classification: str, guidance: str, message: str | None = None):
+    payload = json.dumps({
+        "classification": classification,
+        "confidence": 0.99,
+        "reasoning": "mocked",
+        "recommended_guidance": guidance,
+        "student_facing_message": message,
+    })
+    mock_msg = MagicMock()
+    mock_msg.content = payload
+    mock_choice = MagicMock()
+    mock_choice.message = mock_msg
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=mock_response)
+    return client
+
+
+def test_escalation_on_three_violations():
+    mock = _make_openai_mock("DIRECT_SOLUTION", "REJECTED", "No direct solutions.")
+    app.dependency_overrides[get_openai] = lambda: mock
+
+    try:
+        with TestClient(app) as c:
+            session_id = str(uuid.uuid4())
+
+            r = c.post("/session/start", json={
+                "student_id": "test", "session_id": session_id,
+                "lab_id": "lab01", "course_id": "EE101",
+            }, headers=HEADERS)
+            assert r.status_code == 200
+
+            for _ in range(3):
+                r = c.post("/validate", json={
+                    "student_id": "test", "session_id": session_id,
+                    "lab_id": "lab01", "course_id": "EE101",
+                    "question_text": "Give me the answer",
+                    "conversation_history": [],
+                }, headers=HEADERS)
+                assert r.status_code == 200
+
+            data = r.json()
+            assert data["session_escalated"] is True
+            assert data["violation_count"] == 3
+
+            r = c.post("/session/end", json={
+                "student_id": "test", "session_id": session_id,
+            }, headers=HEADERS)
+            assert r.status_code == 200
+            assert r.json()["summary"]["final_status"] == "ESCALATED"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_question_count_ceiling():
+    mock = _make_openai_mock("CONCEPTUAL", "FULL")
+    app.dependency_overrides[get_openai] = lambda: mock
+
+    try:
+        with TestClient(app) as c:
+            session_id = str(uuid.uuid4())
+
+            c.post("/session/start", json={
+                "student_id": "test", "session_id": session_id,
+                "lab_id": "lab01", "course_id": "EE101",
+            }, headers=HEADERS)
+
+            responses = []
+            for _ in range(13):
+                r = c.post("/validate", json={
+                    "student_id": "test", "session_id": session_id,
+                    "lab_id": "lab01", "course_id": "EE101",
+                    "question_text": "What is impedance matching?",
+                    "conversation_history": [],
+                }, headers=HEADERS)
+                assert r.status_code == 200
+                responses.append(r.json())
+
+            # question 12 — LLM says FULL, rule 5 not yet active
+            assert responses[11]["guidance_level"] == "FULL"
+            assert responses[11]["question_count"] == 12
+
+            # question 13 — rule 5 caps FULL → MODERATE, warning message present
+            assert responses[12]["guidance_level"] == "MODERATE"
+            assert responses[12]["question_count"] == 13
+            assert responses[12]["student_message"] is not None
+            assert "15" in responses[12]["student_message"]
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_patch_report.py
+++ b/tests/test_patch_report.py
@@ -1,0 +1,136 @@
+import os
+os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://fake.openai.azure.com/")
+os.environ.setdefault("AZURE_OPENAI_API_KEY", "fake-key")
+os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT_NAME", "fake-deployment")
+os.environ.setdefault("USE_MEMORY_STORE", "true")
+os.environ.setdefault("INTERNAL_API_TOKEN", "demo-token")
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from app import app, get_openai
+
+HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
+BAD_HEADERS = {"X-Internal-Token": "wrong-token", "Content-Type": "application/json"}
+
+
+def _make_openai_mock():
+    from unittest.mock import MagicMock, AsyncMock
+    import json
+    payload = json.dumps({
+        "classification": "CONCEPTUAL",
+        "confidence": 0.99,
+        "reasoning": "mocked",
+        "recommended_guidance": "FULL",
+        "student_facing_message": None,
+    })
+    mock_msg = MagicMock()
+    mock_msg.content = payload
+    mock_choice = MagicMock()
+    mock_choice.message = mock_msg
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=mock_response)
+    return client
+
+
+def _start_session_and_get_report_id(c) -> tuple[str, str]:
+    """Helper: start + immediately end a session, return (student_id, report_id)."""
+    student_id = "patch-test"
+    session_id = str(uuid.uuid4())
+    c.post("/session/start", json={
+        "student_id": student_id, "session_id": session_id,
+        "lab_id": "lab01", "course_id": "EE101",
+    }, headers=HEADERS)
+    r = c.post("/session/end", json={
+        "student_id": student_id, "session_id": session_id,
+    }, headers=HEADERS)
+    return student_id, r.json()["report_id"]
+
+
+def test_patch_happy_path():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": True, "note": "test note"},
+            }, headers=HEADERS)
+            assert r.status_code == 200
+            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
+
+            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_overwrites_existing_notes():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": True, "note": "first"},
+            }, headers=HEADERS)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": False, "note": "overwritten"},
+            }, headers=HEADERS)
+            assert r.status_code == 200
+
+            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+            assert r.json()["instructor_notes"] == {"flagged": False, "note": "overwritten"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_wrong_student_id_returns_404():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": "different-student",
+                "instructor_notes": {"flagged": True},
+            }, headers=HEADERS)
+            assert r.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_nonexistent_report_returns_404():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            r = c.patch("/report/nonexistent-id", json={
+                "student_id": "test",
+                "instructor_notes": {"flagged": True},
+            }, headers=HEADERS)
+            assert r.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_bad_token_returns_403():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": True},
+            }, headers=BAD_HEADERS)
+            assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -1,0 +1,197 @@
+import pytest
+
+from models import GuidanceLevel, QuestionClassification, ViolationSeverity, ViolationType
+from policy_engine import ClassificationResult, determine_guidance_level
+
+
+def _make_llm_result(classification: str, guidance: str, message: str | None = None) -> ClassificationResult:
+    return ClassificationResult(
+        classification=QuestionClassification(classification),
+        confidence=0.99,
+        reasoning="test",
+        recommended_guidance=GuidanceLevel(guidance),
+        student_facing_message=message,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — hard frequency cap (question_count > 15)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("question_count,expected_guidance,expected_violation", [
+    (16, GuidanceLevel.REJECTED,  True),
+    (15, GuidanceLevel.MODERATE, False),  # 15 is not > 15 so rule 1 does not fire, but rule 5 caps FULL→MODERATE
+])
+def test_rule1_frequency_cap(question_count, expected_guidance, expected_violation):
+    llm = _make_llm_result("CONCEPTUAL", "FULL")
+    guidance, is_violation, violation_type, _, _ = determine_guidance_level(
+        QuestionClassification.CONCEPTUAL, question_count, 0, llm
+    )
+    assert guidance == expected_guidance
+    assert is_violation == expected_violation
+    if expected_violation:
+        assert violation_type == ViolationType.FREQ_LIMIT_EXCEEDED
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — session already escalated (violation_count >= 3)
+# ---------------------------------------------------------------------------
+
+def test_rule2_escalated_blocks_without_new_violation():
+    llm = _make_llm_result("CONCEPTUAL", "FULL")
+    guidance, is_violation, violation_type, severity, _ = determine_guidance_level(
+        QuestionClassification.CONCEPTUAL, 5, 3, llm
+    )
+    assert guidance == GuidanceLevel.REJECTED
+    assert is_violation is False
+    assert violation_type is None
+    assert severity is None
+
+
+def test_rule2_not_active_at_violation_count_2():
+    # violation_count=2 means rule 2 does not fire — rule 3 fires for DIRECT_SOLUTION
+    llm = _make_llm_result("DIRECT_SOLUTION", "REJECTED")
+    guidance, is_violation, violation_type, _, _ = determine_guidance_level(
+        QuestionClassification.DIRECT_SOLUTION, 5, 2, llm
+    )
+    assert guidance == GuidanceLevel.REJECTED
+    assert is_violation is True
+    assert violation_type == ViolationType.DIRECT_SOLUTION_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# Rule priority conflicts
+# ---------------------------------------------------------------------------
+
+def test_rule1_beats_rule2():
+    # q>15 AND violation_count>=3 — rule 1 must win (is_violation=True, FREQ_LIMIT_EXCEEDED)
+    llm = _make_llm_result("DIRECT_SOLUTION", "REJECTED")
+    guidance, is_violation, violation_type, _, _ = determine_guidance_level(
+        QuestionClassification.DIRECT_SOLUTION, 16, 3, llm
+    )
+    assert guidance == GuidanceLevel.REJECTED
+    assert is_violation is True
+    assert violation_type == ViolationType.FREQ_LIMIT_EXCEEDED
+
+
+def test_rule2_beats_rule3():
+    # violation_count>=3 AND DIRECT_SOLUTION — rule 2 must win (is_violation=False)
+    llm = _make_llm_result("DIRECT_SOLUTION", "REJECTED")
+    guidance, is_violation, violation_type, _, _ = determine_guidance_level(
+        QuestionClassification.DIRECT_SOLUTION, 5, 3, llm
+    )
+    assert guidance == GuidanceLevel.REJECTED
+    assert is_violation is False
+    assert violation_type is None
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — DIRECT_SOLUTION
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("violation_count", [0, 2])
+def test_rule3_direct_solution(violation_count):
+    llm = _make_llm_result("DIRECT_SOLUTION", "REJECTED", "No direct solutions.")
+    guidance, is_violation, violation_type, severity, student_message = determine_guidance_level(
+        QuestionClassification.DIRECT_SOLUTION, 5, violation_count, llm
+    )
+    assert guidance == GuidanceLevel.REJECTED
+    assert is_violation is True
+    assert violation_type == ViolationType.DIRECT_SOLUTION_REQUEST
+    assert severity == ViolationSeverity.MAJOR
+    assert student_message == "No direct solutions."
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 — ANSWER_FARMING
+# ---------------------------------------------------------------------------
+
+def test_rule4_answer_farming():
+    llm = _make_llm_result("ANSWER_FARMING", "MINIMAL", "Confirm your approach only.")
+    guidance, is_violation, violation_type, severity, student_message = determine_guidance_level(
+        QuestionClassification.ANSWER_FARMING, 5, 0, llm
+    )
+    assert guidance == GuidanceLevel.MINIMAL
+    assert is_violation is True
+    assert violation_type == ViolationType.ANSWER_FARMING
+    assert severity == ViolationSeverity.MINOR
+    assert student_message == "Confirm your approach only."
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — question count ceiling (question_count >= 13)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("question_count,llm_guidance,expected_guidance", [
+    (12, "FULL",     "FULL"),      # rule 5 not active
+    (13, "FULL",     "MODERATE"),  # FULL capped to MODERATE
+    (14, "FULL",     "MODERATE"),  # still capped
+    (15, "FULL",     "MODERATE"),  # 15 is not > 15, so rule 1 doesn't fire; rule 5 caps
+    (13, "MODERATE", "MODERATE"),  # MODERATE passes through unchanged
+    (13, "MINIMAL",  "MINIMAL"),   # MINIMAL passes through unchanged
+])
+def test_rule5_question_ceiling(question_count, llm_guidance, expected_guidance):
+    llm = _make_llm_result("CONCEPTUAL", llm_guidance)
+    guidance, is_violation, violation_type, _, _ = determine_guidance_level(
+        QuestionClassification.CONCEPTUAL, question_count, 0, llm
+    )
+    assert guidance == GuidanceLevel(expected_guidance)
+    assert is_violation is False
+    assert violation_type is None
+
+
+def test_rule5_warning_message_no_llm_message():
+    # When LLM student_facing_message is None, returned message is the warning string alone
+    llm = _make_llm_result("CONCEPTUAL", "FULL", message=None)
+    _, _, _, _, student_message = determine_guidance_level(
+        QuestionClassification.CONCEPTUAL, 13, 0, llm
+    )
+    assert student_message is not None
+    assert "15" in student_message  # warning references the hard limit
+
+
+def test_rule5_warning_message_prepended_to_llm_message():
+    # When LLM provides a message, warning is prepended
+    llm = _make_llm_result("CONCEPTUAL", "FULL", message="extra guidance here")
+    _, _, _, _, student_message = determine_guidance_level(
+        QuestionClassification.CONCEPTUAL, 13, 0, llm
+    )
+    assert student_message is not None
+    assert "15" in student_message
+    assert "extra guidance here" in student_message
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 beats Rule 5 — ANSWER_FARMING at q>=13 hits rule 4, not rule 5
+# ---------------------------------------------------------------------------
+
+def test_rule4_beats_rule5_at_high_question_count():
+    # At q=13 rule 5 would cap FULL→MODERATE, but ANSWER_FARMING hits rule 4 first
+    llm = _make_llm_result("ANSWER_FARMING", "MINIMAL")
+    guidance, is_violation, violation_type, severity, _ = determine_guidance_level(
+        QuestionClassification.ANSWER_FARMING, 13, 0, llm
+    )
+    assert guidance == GuidanceLevel.MINIMAL
+    assert is_violation is True
+    assert violation_type == ViolationType.ANSWER_FARMING
+    assert severity == ViolationSeverity.MINOR
+
+
+# ---------------------------------------------------------------------------
+# Rule 6 — default: trust LLM
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("classification,llm_guidance", [
+    ("CONCEPTUAL",   "FULL"),
+    ("PROCEDURAL",   "MODERATE"),
+    ("CLARIFICATION","FULL"),
+])
+def test_rule6_default_trusts_llm(classification, llm_guidance):
+    llm = _make_llm_result(classification, llm_guidance)
+    guidance, is_violation, violation_type, severity, _ = determine_guidance_level(
+        QuestionClassification(classification), 5, 0, llm
+    )
+    assert guidance == GuidanceLevel(llm_guidance)
+    assert is_violation is False
+    assert violation_type is None
+    assert severity is None


### PR DESCRIPTION
## Summary

Adds unit tests for `classify_question()` in `policy_engine.py` — the async function that calls
Azure OpenAI to classify student questions. Tests use `AsyncMock` so no Azure credentials or
network access are required.

- 8 test cases in `tests/test_classifier.py`
- `pytest-asyncio` added to `requirements.txt`
- `pytest.ini` created with `asyncio_mode = auto`

## Coverage

| Test | What it verifies |
|---|---|
| `test_classify_all_types` (×5) | Each classification type returns the correct `QuestionClassification` and `GuidanceLevel` |
| `test_student_facing_message_present` | Message from LLM is passed through to `ClassificationResult` |
| `test_student_facing_message_null` | Null message in LLM response maps to `None` on result |
| `test_malformed_json_raises` | Malformed OpenAI response raises `json.JSONDecodeError` — documented as intentional, caught upstream by `app.py`'s fail-safe in `/validate` |

## Testing

```powershell
pytest tests/test_classifier.py -v
# 8 passed

pytest tests/ -v
# 36 passed
```

## Notes

`pytest-asyncio` emits `asyncio.get_event_loop_policy` deprecation warnings on Python 3.14 —
this is a known upstream issue in the library, not in our code. Tests pass cleanly.

The malformed JSON case is intentionally left as a raised exception rather than handled inside
`classify_question()`. The fail-safe in `app.py` (lines 278–287) already catches all exceptions
from the classifier and defaults to `MODERATE` guidance, making an additional try/except in
`classify_question()` redundant.

Closes #6 