### PR TITLE
Feat/integration tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from models import (
     EndSessionResponse,
     GenerateReportRequest,
     GenerateReportResponse,
+    PatchReportRequest,
     GuidanceLevel,
     PostLabCheckRequest,
     PostLabCheckResponse,
@@ -445,3 +446,20 @@ async def get_report(
     if report is None:
         raise HTTPException(status_code=404, detail="Report not found.")
     return report
+
+
+@app.patch(
+    "/report/{report_id}",
+    tags=["reports"],
+    dependencies=[Depends(verify_internal_token)],
+)
+async def patch_report(
+    report_id: str,
+    body: PatchReportRequest,
+    cosmos: CosmosIntegrityClient = Depends(get_cosmos),
+) -> dict:
+    report = await cosmos.get_report(report_id, body.student_id)
+    if report is None:
+        raise HTTPException(status_code=404, detail="Report not found.")
+    report["instructor_notes"] = body.instructor_notes
+    return await cosmos.upsert_report(report)

--- a/cosmos_client.py
+++ b/cosmos_client.py
@@ -107,6 +107,11 @@ class CosmosIntegrityClient:
         except cosmos_exceptions.CosmosResourceNotFoundError:
             return None
 
+    async def upsert_report(self, doc: dict) -> dict:
+        """Insert or replace a report document."""
+        result = await self._reports.upsert_item(body=doc)
+        return result
+
     async def get_reports_for_session(
         self, session_id: str, student_id: str
     ) -> list[dict]:

--- a/cosmos_client_memory.py
+++ b/cosmos_client_memory.py
@@ -66,6 +66,10 @@ class MemoryIntegrityClient:
     async def get_report(self, report_id: str, student_id: str) -> Optional[dict]:
         return self._reports.get(report_id)
 
+    async def upsert_report(self, doc: dict) -> dict:
+        self._reports[doc["id"]] = doc
+        return doc
+
     async def get_reports_for_session(
         self, session_id: str, student_id: str
     ) -> list[dict]:

--- a/cosmos_client_memory.py
+++ b/cosmos_client_memory.py
@@ -37,7 +37,10 @@ class MemoryIntegrityClient:
         return doc
 
     async def get_session(self, session_id: str, student_id: str) -> Optional[dict]:
-        return self._sessions.get(session_id)
+        session = self._sessions.get(session_id)
+        if session is None or session.get("student_id") != student_id:
+            return None
+        return session
 
     async def upsert_session(self, doc: dict) -> dict:
         self._sessions[doc["id"]] = doc
@@ -64,7 +67,10 @@ class MemoryIntegrityClient:
         return doc
 
     async def get_report(self, report_id: str, student_id: str) -> Optional[dict]:
-        return self._reports.get(report_id)
+        report = self._reports.get(report_id)
+        if report is None or report.get("student_id") != student_id:
+            return None
+        return report
 
     async def upsert_report(self, doc: dict) -> dict:
         self._reports[doc["id"]] = doc

--- a/models.py
+++ b/models.py
@@ -116,6 +116,11 @@ class GenerateReportResponse(BaseModel):
     report: dict
 
 
+class PatchReportRequest(BaseModel):
+    student_id: str
+    instructor_notes: dict
+
+
 class PostLabCheckRequest(BaseModel):
     student_id: str
     session_ids: list[str]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ azure-core>=1.37.0,<2
 python-dotenv>=1.2.1,<2
 pydantic>=2.0.0,<3
 pydantic-settings>=2.0.0,<3
+httpx>=0.27.0,<1
+pytest>=8.0.0,<9

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
 
-from app import app, get_openai
+from app import app
 
 HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
 
@@ -36,73 +36,63 @@ def _make_openai_mock(classification: str, guidance: str, message: str | None = 
 
 
 def test_escalation_on_three_violations():
-    mock = _make_openai_mock("DIRECT_SOLUTION", "REJECTED", "No direct solutions.")
-    app.dependency_overrides[get_openai] = lambda: mock
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock("DIRECT_SOLUTION", "REJECTED", "No direct solutions.")
+        session_id = str(uuid.uuid4())
 
-    try:
-        with TestClient(app) as c:
-            session_id = str(uuid.uuid4())
+        r = c.post("/session/start", json={
+            "student_id": "test", "session_id": session_id,
+            "lab_id": "lab01", "course_id": "EE101",
+        }, headers=HEADERS)
+        assert r.status_code == 200
 
-            r = c.post("/session/start", json={
+        for _ in range(3):
+            r = c.post("/validate", json={
                 "student_id": "test", "session_id": session_id,
                 "lab_id": "lab01", "course_id": "EE101",
+                "question_text": "Give me the answer",
+                "conversation_history": [],
             }, headers=HEADERS)
             assert r.status_code == 200
 
-            for _ in range(3):
-                r = c.post("/validate", json={
-                    "student_id": "test", "session_id": session_id,
-                    "lab_id": "lab01", "course_id": "EE101",
-                    "question_text": "Give me the answer",
-                    "conversation_history": [],
-                }, headers=HEADERS)
-                assert r.status_code == 200
+        data = r.json()
+        assert data["session_escalated"] is True
+        assert data["violation_count"] == 3
 
-            data = r.json()
-            assert data["session_escalated"] is True
-            assert data["violation_count"] == 3
-
-            r = c.post("/session/end", json={
-                "student_id": "test", "session_id": session_id,
-            }, headers=HEADERS)
-            assert r.status_code == 200
-            assert r.json()["summary"]["final_status"] == "ESCALATED"
-    finally:
-        app.dependency_overrides.clear()
+        r = c.post("/session/end", json={
+            "student_id": "test", "session_id": session_id,
+        }, headers=HEADERS)
+        assert r.status_code == 200
+        assert r.json()["summary"]["final_status"] == "ESCALATED"
 
 
 def test_question_count_ceiling():
-    mock = _make_openai_mock("CONCEPTUAL", "FULL")
-    app.dependency_overrides[get_openai] = lambda: mock
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock("CONCEPTUAL", "FULL")
+        session_id = str(uuid.uuid4())
 
-    try:
-        with TestClient(app) as c:
-            session_id = str(uuid.uuid4())
+        c.post("/session/start", json={
+            "student_id": "test", "session_id": session_id,
+            "lab_id": "lab01", "course_id": "EE101",
+        }, headers=HEADERS)
 
-            c.post("/session/start", json={
+        responses = []
+        for _ in range(13):
+            r = c.post("/validate", json={
                 "student_id": "test", "session_id": session_id,
                 "lab_id": "lab01", "course_id": "EE101",
+                "question_text": "What is impedance matching?",
+                "conversation_history": [],
             }, headers=HEADERS)
+            assert r.status_code == 200
+            responses.append(r.json())
 
-            responses = []
-            for _ in range(13):
-                r = c.post("/validate", json={
-                    "student_id": "test", "session_id": session_id,
-                    "lab_id": "lab01", "course_id": "EE101",
-                    "question_text": "What is impedance matching?",
-                    "conversation_history": [],
-                }, headers=HEADERS)
-                assert r.status_code == 200
-                responses.append(r.json())
+        # question 12 — LLM says FULL, rule 5 not yet active
+        assert responses[11]["guidance_level"] == "FULL"
+        assert responses[11]["question_count"] == 12
 
-            # question 12 — LLM says FULL, rule 5 not yet active
-            assert responses[11]["guidance_level"] == "FULL"
-            assert responses[11]["question_count"] == 12
-
-            # question 13 — rule 5 caps FULL → MODERATE, warning message present
-            assert responses[12]["guidance_level"] == "MODERATE"
-            assert responses[12]["question_count"] == 13
-            assert responses[12]["student_message"] is not None
-            assert "15" in responses[12]["student_message"]
-    finally:
-        app.dependency_overrides.clear()
+        # question 13 — rule 5 caps FULL → MODERATE, warning message present
+        assert responses[12]["guidance_level"] == "MODERATE"
+        assert responses[12]["question_count"] == 13
+        assert responses[12]["student_message"] is not None
+        assert "15" in responses[12]["student_message"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,108 @@
+import os
+os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://fake.openai.azure.com/")
+os.environ.setdefault("AZURE_OPENAI_API_KEY", "fake-key")
+os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT_NAME", "fake-deployment")
+os.environ.setdefault("USE_MEMORY_STORE", "true")
+os.environ.setdefault("INTERNAL_API_TOKEN", "demo-token")
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from app import app, get_openai
+
+HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
+
+
+def _make_openai_mock(classification: str, guidance: str, message: str | None = None):
+    payload = json.dumps({
+        "classification": classification,
+        "confidence": 0.99,
+        "reasoning": "mocked",
+        "recommended_guidance": guidance,
+        "student_facing_message": message,
+    })
+    mock_msg = MagicMock()
+    mock_msg.content = payload
+    mock_choice = MagicMock()
+    mock_choice.message = mock_msg
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=mock_response)
+    return client
+
+
+def test_escalation_on_three_violations():
+    mock = _make_openai_mock("DIRECT_SOLUTION", "REJECTED", "No direct solutions.")
+    app.dependency_overrides[get_openai] = lambda: mock
+
+    try:
+        with TestClient(app) as c:
+            session_id = str(uuid.uuid4())
+
+            r = c.post("/session/start", json={
+                "student_id": "test", "session_id": session_id,
+                "lab_id": "lab01", "course_id": "EE101",
+            }, headers=HEADERS)
+            assert r.status_code == 200
+
+            for _ in range(3):
+                r = c.post("/validate", json={
+                    "student_id": "test", "session_id": session_id,
+                    "lab_id": "lab01", "course_id": "EE101",
+                    "question_text": "Give me the answer",
+                    "conversation_history": [],
+                }, headers=HEADERS)
+                assert r.status_code == 200
+
+            data = r.json()
+            assert data["session_escalated"] is True
+            assert data["violation_count"] == 3
+
+            r = c.post("/session/end", json={
+                "student_id": "test", "session_id": session_id,
+            }, headers=HEADERS)
+            assert r.status_code == 200
+            assert r.json()["summary"]["final_status"] == "ESCALATED"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_question_count_ceiling():
+    mock = _make_openai_mock("CONCEPTUAL", "FULL")
+    app.dependency_overrides[get_openai] = lambda: mock
+
+    try:
+        with TestClient(app) as c:
+            session_id = str(uuid.uuid4())
+
+            c.post("/session/start", json={
+                "student_id": "test", "session_id": session_id,
+                "lab_id": "lab01", "course_id": "EE101",
+            }, headers=HEADERS)
+
+            responses = []
+            for _ in range(13):
+                r = c.post("/validate", json={
+                    "student_id": "test", "session_id": session_id,
+                    "lab_id": "lab01", "course_id": "EE101",
+                    "question_text": "What is impedance matching?",
+                    "conversation_history": [],
+                }, headers=HEADERS)
+                assert r.status_code == 200
+                responses.append(r.json())
+
+            # question 12 — LLM says FULL, rule 5 not yet active
+            assert responses[11]["guidance_level"] == "FULL"
+            assert responses[11]["question_count"] == 12
+
+            # question 13 — rule 5 caps FULL → MODERATE, warning message present
+            assert responses[12]["guidance_level"] == "MODERATE"
+            assert responses[12]["question_count"] == 13
+            assert responses[12]["student_message"] is not None
+            assert "15" in responses[12]["student_message"]
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_patch_report.py
+++ b/tests/test_patch_report.py
@@ -5,20 +5,19 @@ os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT_NAME", "fake-deployment")
 os.environ.setdefault("USE_MEMORY_STORE", "true")
 os.environ.setdefault("INTERNAL_API_TOKEN", "demo-token")
 
+import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
 
-from app import app, get_openai
+from app import app
 
 HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
 BAD_HEADERS = {"X-Internal-Token": "wrong-token", "Content-Type": "application/json"}
 
 
 def _make_openai_mock():
-    from unittest.mock import MagicMock, AsyncMock
-    import json
     payload = json.dumps({
         "classification": "CONCEPTUAL",
         "confidence": 0.99,
@@ -52,85 +51,70 @@ def _start_session_and_get_report_id(c) -> tuple[str, str]:
 
 
 def test_patch_happy_path():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            student_id, report_id = _start_session_and_get_report_id(c)
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        student_id, report_id = _start_session_and_get_report_id(c)
 
-            r = c.patch(f"/report/{report_id}", json={
-                "student_id": student_id,
-                "instructor_notes": {"flagged": True, "note": "test note"},
-            }, headers=HEADERS)
-            assert r.status_code == 200
-            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
+        r = c.patch(f"/report/{report_id}", json={
+            "student_id": student_id,
+            "instructor_notes": {"flagged": True, "note": "test note"},
+        }, headers=HEADERS)
+        assert r.status_code == 200
+        assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
 
-            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
-            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
-    finally:
-        app.dependency_overrides.clear()
+        r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+        assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
 
 
 def test_patch_overwrites_existing_notes():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            student_id, report_id = _start_session_and_get_report_id(c)
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        student_id, report_id = _start_session_and_get_report_id(c)
 
-            c.patch(f"/report/{report_id}", json={
-                "student_id": student_id,
-                "instructor_notes": {"flagged": True, "note": "first"},
-            }, headers=HEADERS)
+        c.patch(f"/report/{report_id}", json={
+            "student_id": student_id,
+            "instructor_notes": {"flagged": True, "note": "first"},
+        }, headers=HEADERS)
 
-            r = c.patch(f"/report/{report_id}", json={
-                "student_id": student_id,
-                "instructor_notes": {"flagged": False, "note": "overwritten"},
-            }, headers=HEADERS)
-            assert r.status_code == 200
+        r = c.patch(f"/report/{report_id}", json={
+            "student_id": student_id,
+            "instructor_notes": {"flagged": False, "note": "overwritten"},
+        }, headers=HEADERS)
+        assert r.status_code == 200
 
-            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
-            assert r.json()["instructor_notes"] == {"flagged": False, "note": "overwritten"}
-    finally:
-        app.dependency_overrides.clear()
+        r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+        assert r.json()["instructor_notes"] == {"flagged": False, "note": "overwritten"}
 
 
 def test_patch_wrong_student_id_returns_404():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            student_id, report_id = _start_session_and_get_report_id(c)
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        student_id, report_id = _start_session_and_get_report_id(c)
 
-            r = c.patch(f"/report/{report_id}", json={
-                "student_id": "different-student",
-                "instructor_notes": {"flagged": True},
-            }, headers=HEADERS)
-            assert r.status_code == 404
-    finally:
-        app.dependency_overrides.clear()
+        r = c.patch(f"/report/{report_id}", json={
+            "student_id": "different-student",
+            "instructor_notes": {"flagged": True},
+        }, headers=HEADERS)
+        assert r.status_code == 404
 
 
 def test_patch_nonexistent_report_returns_404():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            r = c.patch("/report/nonexistent-id", json={
-                "student_id": "test",
-                "instructor_notes": {"flagged": True},
-            }, headers=HEADERS)
-            assert r.status_code == 404
-    finally:
-        app.dependency_overrides.clear()
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        r = c.patch("/report/nonexistent-id", json={
+            "student_id": "test",
+            "instructor_notes": {"flagged": True},
+        }, headers=HEADERS)
+        assert r.status_code == 404
 
 
 def test_patch_bad_token_returns_403():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            student_id, report_id = _start_session_and_get_report_id(c)
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        student_id, report_id = _start_session_and_get_report_id(c)
 
-            r = c.patch(f"/report/{report_id}", json={
-                "student_id": student_id,
-                "instructor_notes": {"flagged": True},
-            }, headers=BAD_HEADERS)
-            assert r.status_code == 403
-    finally:
-        app.dependency_overrides.clear()
+        r = c.patch(f"/report/{report_id}", json={
+            "student_id": student_id,
+            "instructor_notes": {"flagged": True},
+        }, headers=BAD_HEADERS)
+        assert r.status_code == 403

--- a/tests/test_patch_report.py
+++ b/tests/test_patch_report.py
@@ -1,0 +1,136 @@
+import os
+os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://fake.openai.azure.com/")
+os.environ.setdefault("AZURE_OPENAI_API_KEY", "fake-key")
+os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT_NAME", "fake-deployment")
+os.environ.setdefault("USE_MEMORY_STORE", "true")
+os.environ.setdefault("INTERNAL_API_TOKEN", "demo-token")
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from app import app, get_openai
+
+HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
+BAD_HEADERS = {"X-Internal-Token": "wrong-token", "Content-Type": "application/json"}
+
+
+def _make_openai_mock():
+    from unittest.mock import MagicMock, AsyncMock
+    import json
+    payload = json.dumps({
+        "classification": "CONCEPTUAL",
+        "confidence": 0.99,
+        "reasoning": "mocked",
+        "recommended_guidance": "FULL",
+        "student_facing_message": None,
+    })
+    mock_msg = MagicMock()
+    mock_msg.content = payload
+    mock_choice = MagicMock()
+    mock_choice.message = mock_msg
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=mock_response)
+    return client
+
+
+def _start_session_and_get_report_id(c) -> tuple[str, str]:
+    """Helper: start + immediately end a session, return (student_id, report_id)."""
+    student_id = "patch-test"
+    session_id = str(uuid.uuid4())
+    c.post("/session/start", json={
+        "student_id": student_id, "session_id": session_id,
+        "lab_id": "lab01", "course_id": "EE101",
+    }, headers=HEADERS)
+    r = c.post("/session/end", json={
+        "student_id": student_id, "session_id": session_id,
+    }, headers=HEADERS)
+    return student_id, r.json()["report_id"]
+
+
+def test_patch_happy_path():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": True, "note": "test note"},
+            }, headers=HEADERS)
+            assert r.status_code == 200
+            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
+
+            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_overwrites_existing_notes():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": True, "note": "first"},
+            }, headers=HEADERS)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": False, "note": "overwritten"},
+            }, headers=HEADERS)
+            assert r.status_code == 200
+
+            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+            assert r.json()["instructor_notes"] == {"flagged": False, "note": "overwritten"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_wrong_student_id_returns_404():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": "different-student",
+                "instructor_notes": {"flagged": True},
+            }, headers=HEADERS)
+            assert r.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_nonexistent_report_returns_404():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            r = c.patch("/report/nonexistent-id", json={
+                "student_id": "test",
+                "instructor_notes": {"flagged": True},
+            }, headers=HEADERS)
+            assert r.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_bad_token_returns_403():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": True},
+            }, headers=BAD_HEADERS)
+            assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

Adds full end-to-end integration tests using FastAPI's `TestClient` and `MemoryIntegrityClient`
with a mocked OpenAI client — no Azure credentials or Cosmos DB required. A new developer can
clone the repo and run `pytest tests/` immediately.

Also fixes a bug discovered during testing: `MemoryIntegrityClient.get_session()` and
`get_report()` were ignoring the `student_id` partition key, allowing any student ID to access
any session or report. Fixed to match the real Cosmos DB behaviour (point-read by ID +
partition key).

- `tests/test_integration.py` — two scenario tests
- `tests/test_patch_report.py` — five PATCH endpoint tests (written alongside to prove Issue #3
  with a permanent repeatable test rather than a manual script)
- OpenAI mock injected via `app.state` after lifespan startup

## Scenarios covered

**Scenario 1 — Escalation flow**
- Start session → send 3 `DIRECT_SOLUTION` questions → assert `session_escalated: true`,
  `violation_count: 3` → end session → assert `final_status: ESCALATED`

**Scenario 2 — Question count ceiling**
- Start session → send 13 `CONCEPTUAL` questions → assert q12 gets `FULL` guidance →
  assert q13 gets `MODERATE` with warning message containing "15"

## Bug fixed

`MemoryIntegrityClient.get_session()` and `get_report()` did not check `student_id`, meaning
a request with a wrong student ID would return 200 instead of 404. In production Cosmos DB,
`student_id` is the partition key so a wrong value correctly returns not-found. The memory
client now matches this behaviour.

## Testing

```powershell
pytest tests/ -v
# 36 passed (including D1 and D2 tests)
```

Zero Azure setup required — all tests run with in-memory store and mocked OpenAI.

closes #7 