### PR TITLE
Feat/validate rate limiting

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ Co-pilot when thresholds are exceeded, and generates end-of-session and
 post-lab integrity reports.
 """
 
+import json as _json
 import logging
 import uuid
 from contextlib import asynccontextmanager
@@ -14,8 +15,12 @@ from datetime import datetime
 from typing import Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
 from openai import AsyncAzureOpenAI, RateLimitError
 from pydantic_settings import BaseSettings
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
 from cosmos_client import CosmosIntegrityClient
 from cosmos_client_memory import MemoryIntegrityClient
@@ -74,6 +79,18 @@ logger = logging.getLogger(__name__)
 # Application lifespan
 # ---------------------------------------------------------------------------
 
+def _key_by_student_id(request: Request) -> str:
+    body = getattr(request.state, "_body", None)
+    if body:
+        try:
+            return _json.loads(body).get("student_id", "unknown")
+        except Exception:
+            pass
+    return "unknown"
+
+limiter = Limiter(key_func=_key_by_student_id)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     if settings.USE_MEMORY_STORE:
@@ -108,6 +125,25 @@ app = FastAPI(
     description="Policy and integrity middleware for Cal Poly STEM lab AI tutoring.",
     lifespan=lifespan,
 )
+
+app.state.limiter = limiter
+app.add_middleware(SlowAPIMiddleware)
+
+
+@app.middleware("http")
+async def _cache_request_body(request: Request, call_next):
+    body = await request.body()
+    request.state._body = body
+    return await call_next(request)
+
+
+@app.exception_handler(RateLimitExceeded)
+async def _rate_limit_handler(request: Request, exc: RateLimitExceeded):
+    return JSONResponse(
+        status_code=429,
+        content={"detail": "Rate limit exceeded. Please slow down and try again shortly."},
+    )
+
 
 # ---------------------------------------------------------------------------
 # Dependencies
@@ -240,7 +276,9 @@ async def get_session(
     tags=["validation"],
     dependencies=[Depends(verify_internal_token)],
 )
+@limiter.limit("60/minute")
 async def validate_question(
+    request: Request,
     body: ValidateQuestionRequest,
     cosmos: CosmosIntegrityClient = Depends(get_cosmos),
     openai_client: AsyncAzureOpenAI = Depends(get_openai),

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from models import (
     EndSessionResponse,
     GenerateReportRequest,
     GenerateReportResponse,
+    PatchReportRequest,
     GuidanceLevel,
     PostLabCheckRequest,
     PostLabCheckResponse,
@@ -445,3 +446,20 @@ async def get_report(
     if report is None:
         raise HTTPException(status_code=404, detail="Report not found.")
     return report
+
+
+@app.patch(
+    "/report/{report_id}",
+    tags=["reports"],
+    dependencies=[Depends(verify_internal_token)],
+)
+async def patch_report(
+    report_id: str,
+    body: PatchReportRequest,
+    cosmos: CosmosIntegrityClient = Depends(get_cosmos),
+) -> dict:
+    report = await cosmos.get_report(report_id, body.student_id)
+    if report is None:
+        raise HTTPException(status_code=404, detail="Report not found.")
+    report["instructor_notes"] = body.instructor_notes
+    return await cosmos.upsert_report(report)

--- a/cosmos_client.py
+++ b/cosmos_client.py
@@ -107,6 +107,11 @@ class CosmosIntegrityClient:
         except cosmos_exceptions.CosmosResourceNotFoundError:
             return None
 
+    async def upsert_report(self, doc: dict) -> dict:
+        """Insert or replace a report document."""
+        result = await self._reports.upsert_item(body=doc)
+        return result
+
     async def get_reports_for_session(
         self, session_id: str, student_id: str
     ) -> list[dict]:

--- a/cosmos_client_memory.py
+++ b/cosmos_client_memory.py
@@ -66,6 +66,10 @@ class MemoryIntegrityClient:
     async def get_report(self, report_id: str, student_id: str) -> Optional[dict]:
         return self._reports.get(report_id)
 
+    async def upsert_report(self, doc: dict) -> dict:
+        self._reports[doc["id"]] = doc
+        return doc
+
     async def get_reports_for_session(
         self, session_id: str, student_id: str
     ) -> list[dict]:

--- a/cosmos_client_memory.py
+++ b/cosmos_client_memory.py
@@ -37,7 +37,10 @@ class MemoryIntegrityClient:
         return doc
 
     async def get_session(self, session_id: str, student_id: str) -> Optional[dict]:
-        return self._sessions.get(session_id)
+        session = self._sessions.get(session_id)
+        if session is None or session.get("student_id") != student_id:
+            return None
+        return session
 
     async def upsert_session(self, doc: dict) -> dict:
         self._sessions[doc["id"]] = doc
@@ -64,7 +67,10 @@ class MemoryIntegrityClient:
         return doc
 
     async def get_report(self, report_id: str, student_id: str) -> Optional[dict]:
-        return self._reports.get(report_id)
+        report = self._reports.get(report_id)
+        if report is None or report.get("student_id") != student_id:
+            return None
+        return report
 
     async def upsert_report(self, doc: dict) -> dict:
         self._reports[doc["id"]] = doc

--- a/models.py
+++ b/models.py
@@ -116,6 +116,11 @@ class GenerateReportResponse(BaseModel):
     report: dict
 
 
+class PatchReportRequest(BaseModel):
+    student_id: str
+    instructor_notes: dict
+
+
 class PostLabCheckRequest(BaseModel):
     student_id: str
     session_ids: list[str]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ python-dotenv>=1.2.1,<2
 pydantic>=2.0.0,<3
 pydantic-settings>=2.0.0,<3
 httpx>=0.27.0,<1
+slowapi>=0.1.9,<1
 pytest>=8.0.0,<9

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ azure-core>=1.37.0,<2
 python-dotenv>=1.2.1,<2
 pydantic>=2.0.0,<3
 pydantic-settings>=2.0.0,<3
+httpx>=0.27.0,<1
+pytest>=8.0.0,<9

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -96,3 +96,28 @@ def test_question_count_ceiling():
         assert responses[12]["question_count"] == 13
         assert responses[12]["student_message"] is not None
         assert "15" in responses[12]["student_message"]
+
+
+def test_validate_rate_limit():
+    # UUID-based student_id ensures this test never shares quota with others
+    student_id = f"rate-limit-{uuid.uuid4()}"
+
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock("CONCEPTUAL", "FULL")
+
+        statuses = []
+        for _ in range(61):
+            r = c.post("/validate", json={
+                "student_id": student_id,
+                "session_id": "fake-session",
+                "lab_id": "lab01",
+                "course_id": "EE101",
+                "question_text": "test",
+                "conversation_history": [],
+            }, headers=HEADERS)
+            statuses.append(r.status_code)
+
+        # First 60 should not be rate limited (404 — session not found)
+        assert all(s != 429 for s in statuses[:60])
+        # 61st must be rate limited
+        assert statuses[60] == 429

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
 
-from app import app, get_openai
+from app import app
 
 HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
 
@@ -36,73 +36,63 @@ def _make_openai_mock(classification: str, guidance: str, message: str | None = 
 
 
 def test_escalation_on_three_violations():
-    mock = _make_openai_mock("DIRECT_SOLUTION", "REJECTED", "No direct solutions.")
-    app.dependency_overrides[get_openai] = lambda: mock
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock("DIRECT_SOLUTION", "REJECTED", "No direct solutions.")
+        session_id = str(uuid.uuid4())
 
-    try:
-        with TestClient(app) as c:
-            session_id = str(uuid.uuid4())
+        r = c.post("/session/start", json={
+            "student_id": "test", "session_id": session_id,
+            "lab_id": "lab01", "course_id": "EE101",
+        }, headers=HEADERS)
+        assert r.status_code == 200
 
-            r = c.post("/session/start", json={
+        for _ in range(3):
+            r = c.post("/validate", json={
                 "student_id": "test", "session_id": session_id,
                 "lab_id": "lab01", "course_id": "EE101",
+                "question_text": "Give me the answer",
+                "conversation_history": [],
             }, headers=HEADERS)
             assert r.status_code == 200
 
-            for _ in range(3):
-                r = c.post("/validate", json={
-                    "student_id": "test", "session_id": session_id,
-                    "lab_id": "lab01", "course_id": "EE101",
-                    "question_text": "Give me the answer",
-                    "conversation_history": [],
-                }, headers=HEADERS)
-                assert r.status_code == 200
+        data = r.json()
+        assert data["session_escalated"] is True
+        assert data["violation_count"] == 3
 
-            data = r.json()
-            assert data["session_escalated"] is True
-            assert data["violation_count"] == 3
-
-            r = c.post("/session/end", json={
-                "student_id": "test", "session_id": session_id,
-            }, headers=HEADERS)
-            assert r.status_code == 200
-            assert r.json()["summary"]["final_status"] == "ESCALATED"
-    finally:
-        app.dependency_overrides.clear()
+        r = c.post("/session/end", json={
+            "student_id": "test", "session_id": session_id,
+        }, headers=HEADERS)
+        assert r.status_code == 200
+        assert r.json()["summary"]["final_status"] == "ESCALATED"
 
 
 def test_question_count_ceiling():
-    mock = _make_openai_mock("CONCEPTUAL", "FULL")
-    app.dependency_overrides[get_openai] = lambda: mock
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock("CONCEPTUAL", "FULL")
+        session_id = str(uuid.uuid4())
 
-    try:
-        with TestClient(app) as c:
-            session_id = str(uuid.uuid4())
+        c.post("/session/start", json={
+            "student_id": "test", "session_id": session_id,
+            "lab_id": "lab01", "course_id": "EE101",
+        }, headers=HEADERS)
 
-            c.post("/session/start", json={
+        responses = []
+        for _ in range(13):
+            r = c.post("/validate", json={
                 "student_id": "test", "session_id": session_id,
                 "lab_id": "lab01", "course_id": "EE101",
+                "question_text": "What is impedance matching?",
+                "conversation_history": [],
             }, headers=HEADERS)
+            assert r.status_code == 200
+            responses.append(r.json())
 
-            responses = []
-            for _ in range(13):
-                r = c.post("/validate", json={
-                    "student_id": "test", "session_id": session_id,
-                    "lab_id": "lab01", "course_id": "EE101",
-                    "question_text": "What is impedance matching?",
-                    "conversation_history": [],
-                }, headers=HEADERS)
-                assert r.status_code == 200
-                responses.append(r.json())
+        # question 12 — LLM says FULL, rule 5 not yet active
+        assert responses[11]["guidance_level"] == "FULL"
+        assert responses[11]["question_count"] == 12
 
-            # question 12 — LLM says FULL, rule 5 not yet active
-            assert responses[11]["guidance_level"] == "FULL"
-            assert responses[11]["question_count"] == 12
-
-            # question 13 — rule 5 caps FULL → MODERATE, warning message present
-            assert responses[12]["guidance_level"] == "MODERATE"
-            assert responses[12]["question_count"] == 13
-            assert responses[12]["student_message"] is not None
-            assert "15" in responses[12]["student_message"]
-    finally:
-        app.dependency_overrides.clear()
+        # question 13 — rule 5 caps FULL → MODERATE, warning message present
+        assert responses[12]["guidance_level"] == "MODERATE"
+        assert responses[12]["question_count"] == 13
+        assert responses[12]["student_message"] is not None
+        assert "15" in responses[12]["student_message"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,108 @@
+import os
+os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://fake.openai.azure.com/")
+os.environ.setdefault("AZURE_OPENAI_API_KEY", "fake-key")
+os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT_NAME", "fake-deployment")
+os.environ.setdefault("USE_MEMORY_STORE", "true")
+os.environ.setdefault("INTERNAL_API_TOKEN", "demo-token")
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from app import app, get_openai
+
+HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
+
+
+def _make_openai_mock(classification: str, guidance: str, message: str | None = None):
+    payload = json.dumps({
+        "classification": classification,
+        "confidence": 0.99,
+        "reasoning": "mocked",
+        "recommended_guidance": guidance,
+        "student_facing_message": message,
+    })
+    mock_msg = MagicMock()
+    mock_msg.content = payload
+    mock_choice = MagicMock()
+    mock_choice.message = mock_msg
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=mock_response)
+    return client
+
+
+def test_escalation_on_three_violations():
+    mock = _make_openai_mock("DIRECT_SOLUTION", "REJECTED", "No direct solutions.")
+    app.dependency_overrides[get_openai] = lambda: mock
+
+    try:
+        with TestClient(app) as c:
+            session_id = str(uuid.uuid4())
+
+            r = c.post("/session/start", json={
+                "student_id": "test", "session_id": session_id,
+                "lab_id": "lab01", "course_id": "EE101",
+            }, headers=HEADERS)
+            assert r.status_code == 200
+
+            for _ in range(3):
+                r = c.post("/validate", json={
+                    "student_id": "test", "session_id": session_id,
+                    "lab_id": "lab01", "course_id": "EE101",
+                    "question_text": "Give me the answer",
+                    "conversation_history": [],
+                }, headers=HEADERS)
+                assert r.status_code == 200
+
+            data = r.json()
+            assert data["session_escalated"] is True
+            assert data["violation_count"] == 3
+
+            r = c.post("/session/end", json={
+                "student_id": "test", "session_id": session_id,
+            }, headers=HEADERS)
+            assert r.status_code == 200
+            assert r.json()["summary"]["final_status"] == "ESCALATED"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_question_count_ceiling():
+    mock = _make_openai_mock("CONCEPTUAL", "FULL")
+    app.dependency_overrides[get_openai] = lambda: mock
+
+    try:
+        with TestClient(app) as c:
+            session_id = str(uuid.uuid4())
+
+            c.post("/session/start", json={
+                "student_id": "test", "session_id": session_id,
+                "lab_id": "lab01", "course_id": "EE101",
+            }, headers=HEADERS)
+
+            responses = []
+            for _ in range(13):
+                r = c.post("/validate", json={
+                    "student_id": "test", "session_id": session_id,
+                    "lab_id": "lab01", "course_id": "EE101",
+                    "question_text": "What is impedance matching?",
+                    "conversation_history": [],
+                }, headers=HEADERS)
+                assert r.status_code == 200
+                responses.append(r.json())
+
+            # question 12 — LLM says FULL, rule 5 not yet active
+            assert responses[11]["guidance_level"] == "FULL"
+            assert responses[11]["question_count"] == 12
+
+            # question 13 — rule 5 caps FULL → MODERATE, warning message present
+            assert responses[12]["guidance_level"] == "MODERATE"
+            assert responses[12]["question_count"] == 13
+            assert responses[12]["student_message"] is not None
+            assert "15" in responses[12]["student_message"]
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_patch_report.py
+++ b/tests/test_patch_report.py
@@ -5,20 +5,19 @@ os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT_NAME", "fake-deployment")
 os.environ.setdefault("USE_MEMORY_STORE", "true")
 os.environ.setdefault("INTERNAL_API_TOKEN", "demo-token")
 
+import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
 
-from app import app, get_openai
+from app import app
 
 HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
 BAD_HEADERS = {"X-Internal-Token": "wrong-token", "Content-Type": "application/json"}
 
 
 def _make_openai_mock():
-    from unittest.mock import MagicMock, AsyncMock
-    import json
     payload = json.dumps({
         "classification": "CONCEPTUAL",
         "confidence": 0.99,
@@ -52,85 +51,70 @@ def _start_session_and_get_report_id(c) -> tuple[str, str]:
 
 
 def test_patch_happy_path():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            student_id, report_id = _start_session_and_get_report_id(c)
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        student_id, report_id = _start_session_and_get_report_id(c)
 
-            r = c.patch(f"/report/{report_id}", json={
-                "student_id": student_id,
-                "instructor_notes": {"flagged": True, "note": "test note"},
-            }, headers=HEADERS)
-            assert r.status_code == 200
-            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
+        r = c.patch(f"/report/{report_id}", json={
+            "student_id": student_id,
+            "instructor_notes": {"flagged": True, "note": "test note"},
+        }, headers=HEADERS)
+        assert r.status_code == 200
+        assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
 
-            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
-            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
-    finally:
-        app.dependency_overrides.clear()
+        r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+        assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
 
 
 def test_patch_overwrites_existing_notes():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            student_id, report_id = _start_session_and_get_report_id(c)
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        student_id, report_id = _start_session_and_get_report_id(c)
 
-            c.patch(f"/report/{report_id}", json={
-                "student_id": student_id,
-                "instructor_notes": {"flagged": True, "note": "first"},
-            }, headers=HEADERS)
+        c.patch(f"/report/{report_id}", json={
+            "student_id": student_id,
+            "instructor_notes": {"flagged": True, "note": "first"},
+        }, headers=HEADERS)
 
-            r = c.patch(f"/report/{report_id}", json={
-                "student_id": student_id,
-                "instructor_notes": {"flagged": False, "note": "overwritten"},
-            }, headers=HEADERS)
-            assert r.status_code == 200
+        r = c.patch(f"/report/{report_id}", json={
+            "student_id": student_id,
+            "instructor_notes": {"flagged": False, "note": "overwritten"},
+        }, headers=HEADERS)
+        assert r.status_code == 200
 
-            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
-            assert r.json()["instructor_notes"] == {"flagged": False, "note": "overwritten"}
-    finally:
-        app.dependency_overrides.clear()
+        r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+        assert r.json()["instructor_notes"] == {"flagged": False, "note": "overwritten"}
 
 
 def test_patch_wrong_student_id_returns_404():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            student_id, report_id = _start_session_and_get_report_id(c)
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        student_id, report_id = _start_session_and_get_report_id(c)
 
-            r = c.patch(f"/report/{report_id}", json={
-                "student_id": "different-student",
-                "instructor_notes": {"flagged": True},
-            }, headers=HEADERS)
-            assert r.status_code == 404
-    finally:
-        app.dependency_overrides.clear()
+        r = c.patch(f"/report/{report_id}", json={
+            "student_id": "different-student",
+            "instructor_notes": {"flagged": True},
+        }, headers=HEADERS)
+        assert r.status_code == 404
 
 
 def test_patch_nonexistent_report_returns_404():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            r = c.patch("/report/nonexistent-id", json={
-                "student_id": "test",
-                "instructor_notes": {"flagged": True},
-            }, headers=HEADERS)
-            assert r.status_code == 404
-    finally:
-        app.dependency_overrides.clear()
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        r = c.patch("/report/nonexistent-id", json={
+            "student_id": "test",
+            "instructor_notes": {"flagged": True},
+        }, headers=HEADERS)
+        assert r.status_code == 404
 
 
 def test_patch_bad_token_returns_403():
-    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
-    try:
-        with TestClient(app) as c:
-            student_id, report_id = _start_session_and_get_report_id(c)
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        student_id, report_id = _start_session_and_get_report_id(c)
 
-            r = c.patch(f"/report/{report_id}", json={
-                "student_id": student_id,
-                "instructor_notes": {"flagged": True},
-            }, headers=BAD_HEADERS)
-            assert r.status_code == 403
-    finally:
-        app.dependency_overrides.clear()
+        r = c.patch(f"/report/{report_id}", json={
+            "student_id": student_id,
+            "instructor_notes": {"flagged": True},
+        }, headers=BAD_HEADERS)
+        assert r.status_code == 403

--- a/tests/test_patch_report.py
+++ b/tests/test_patch_report.py
@@ -1,0 +1,136 @@
+import os
+os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://fake.openai.azure.com/")
+os.environ.setdefault("AZURE_OPENAI_API_KEY", "fake-key")
+os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT_NAME", "fake-deployment")
+os.environ.setdefault("USE_MEMORY_STORE", "true")
+os.environ.setdefault("INTERNAL_API_TOKEN", "demo-token")
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from app import app, get_openai
+
+HEADERS = {"X-Internal-Token": "demo-token", "Content-Type": "application/json"}
+BAD_HEADERS = {"X-Internal-Token": "wrong-token", "Content-Type": "application/json"}
+
+
+def _make_openai_mock():
+    from unittest.mock import MagicMock, AsyncMock
+    import json
+    payload = json.dumps({
+        "classification": "CONCEPTUAL",
+        "confidence": 0.99,
+        "reasoning": "mocked",
+        "recommended_guidance": "FULL",
+        "student_facing_message": None,
+    })
+    mock_msg = MagicMock()
+    mock_msg.content = payload
+    mock_choice = MagicMock()
+    mock_choice.message = mock_msg
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=mock_response)
+    return client
+
+
+def _start_session_and_get_report_id(c) -> tuple[str, str]:
+    """Helper: start + immediately end a session, return (student_id, report_id)."""
+    student_id = "patch-test"
+    session_id = str(uuid.uuid4())
+    c.post("/session/start", json={
+        "student_id": student_id, "session_id": session_id,
+        "lab_id": "lab01", "course_id": "EE101",
+    }, headers=HEADERS)
+    r = c.post("/session/end", json={
+        "student_id": student_id, "session_id": session_id,
+    }, headers=HEADERS)
+    return student_id, r.json()["report_id"]
+
+
+def test_patch_happy_path():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": True, "note": "test note"},
+            }, headers=HEADERS)
+            assert r.status_code == 200
+            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
+
+            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+            assert r.json()["instructor_notes"] == {"flagged": True, "note": "test note"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_overwrites_existing_notes():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": True, "note": "first"},
+            }, headers=HEADERS)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": False, "note": "overwritten"},
+            }, headers=HEADERS)
+            assert r.status_code == 200
+
+            r = c.get(f"/report/{report_id}", params={"student_id": student_id}, headers=HEADERS)
+            assert r.json()["instructor_notes"] == {"flagged": False, "note": "overwritten"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_wrong_student_id_returns_404():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": "different-student",
+                "instructor_notes": {"flagged": True},
+            }, headers=HEADERS)
+            assert r.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_nonexistent_report_returns_404():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            r = c.patch("/report/nonexistent-id", json={
+                "student_id": "test",
+                "instructor_notes": {"flagged": True},
+            }, headers=HEADERS)
+            assert r.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_patch_bad_token_returns_403():
+    app.dependency_overrides[get_openai] = lambda: _make_openai_mock()
+    try:
+        with TestClient(app) as c:
+            student_id, report_id = _start_session_and_get_report_id(c)
+
+            r = c.patch(f"/report/{report_id}", json={
+                "student_id": student_id,
+                "instructor_notes": {"flagged": True},
+            }, headers=BAD_HEADERS)
+            assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

Adds a 60 requests/minute rate limit on `POST /validate` using `slowapi`. The limit is keyed
by `student_id` from the request body — not by IP — because all requests arrive from Lab
Companion's single container IP, which would cause IP-based limiting to block every student
at once.

A real session never exceeds 15 questions total, so this limit only fires on bugs or retry
loops in Lab Companion, not on normal usage.

- `slowapi>=0.1.9` added to `requirements.txt`
- Body-caching middleware added to `app.py` so the key function can read `student_id` before
  FastAPI parses the Pydantic model
- Rate limit applied to `/validate` only — no other endpoints are affected
- 429 returns `{"detail": "Rate limit exceeded. Please slow down and try again shortly."}`

## Changes to app.py

- `_key_by_student_id()` — key function that extracts `student_id` from the cached request body
- `limiter` — module-level `Limiter` instance
- `SlowAPIMiddleware` — wired into the app
- `_cache_request_body` middleware — reads and caches raw body bytes on `request.state._body`
  before the rate limiter key function runs
- `_rate_limit_handler` — exception handler returning clean 429 JSON
- `@limiter.limit("60/minute")` — applied to `validate_question` only
- `request: Request` — added as first parameter of `validate_question` (required by slowapi)

## Testing

```powershell
pytest tests/test_integration.py -v
# 3 passed — includes test_validate_rate_limit which sends 61 requests and
# asserts the first 60 return non-429 and the 61st returns 429
```

Manual smoke test (confirm normal traffic is unaffected):
```powershell
Invoke-WebRequest -Uri http://localhost:8001/validate -Method POST -Headers @{"X-Internal-Token"="demo-token";"Content-Type"="application/json"} -Body '{"student_id":"test","session_id":"fake","lab_id":"lab01","course_id":"EE101","question_text":"hello","conversation_history":[]}'
# Expected: 404 {"detail":"Session not found."}
```

## Notes

- The `_cache_request_body` middleware must execute before `SlowAPIMiddleware` — this is
  guaranteed by Starlette's LIFO middleware ordering (last added = first executed)
- `student_id` defaults to `"unknown"` if the body cannot be parsed — all unparseable requests
  share one quota bucket, which is acceptable since `ValidateQuestionRequest` enforces the field
- The `slowapi` library emits an `asyncio.iscoroutinefunction` deprecation warning on Python
  3.14 — this is a known upstream issue, not in our code

Closes #8 