### PR TITLE
refactor: implement AIEIC interface contract endpoints and update tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-EXPOSE 8000
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE 8001
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Everything else is pre-set for demo mode (`USE_MEMORY_STORE=true`, `INTERNAL_API
 
 **5. Start the server** (Terminal 1)
 ```bash
-uvicorn app:app --reload
+uvicorn app:app --reload --port 8001
 ```
+
+The service listens on port **8001** to match the AIEIC interface contract.
 
 **6. Run the demo script** (Terminal 2)
 ```bash
@@ -128,12 +130,59 @@ All endpoints except `/health` require the header:
 X-Internal-Token: <INTERNAL_API_TOKEN>
 ```
 
-### `GET /health`
-Liveness probe. No auth required.
+### `GET /` and `GET /health`
+Liveness probes per the AIEIC interface contract. No auth required.
+
+```json
+GET /       → { "status": "ok",      "agent": "integrity", "version": "0.1.0" }
+GET /health → { "status": "healthy", "agent": "integrity", "version": "0.1.0",
+                "timestamp": "2026-04-13T10:00:00Z" }
+```
+
+---
+
+### `POST /integrity/log` ★ Contract endpoint
+Fire-and-forget interaction log called by the Orchestrator after every student message.
+Auto-creates the session document if it does not yet exist, then classifies the message
+internally (running the same violation/escalation logic as `/validate`).
+
+**Request**
+```json
+{
+  "student_id": "alex_m",
+  "session_id": "550e8400-...",
+  "message": "How do I insert at position 3?",
+  "response_time_ms": 1234,
+  "lab_id": "lab4",
+  "course_id": "CSC580"
+}
+```
+`response_time_ms`, `lab_id`, and `course_id` are optional.
 
 **Response**
 ```json
-{ "status": "ok", "timestamp": "2026-04-13T10:00:00Z" }
+{ "status": "ok", "interaction_id": "uuid" }
+```
+
+---
+
+### `GET /integrity/context/{student_id}` ★ Contract endpoint
+Returns the student's aggregated learning profile across all sessions.
+
+**Response**
+```json
+{
+  "total_questions": 12,
+  "question_type_distribution": {
+    "CONCEPTUAL": 3, "PROCEDURAL": 7, "CLARIFICATION": 2,
+    "DIRECT_SOLUTION": 0, "ANSWER_FARMING": 0
+  },
+  "avg_hint_level": 1.8,
+  "sessions_count": 3,
+  "avg_questions_per_session": 4.0,
+  "session_help_frequency": { "sess1": 5, "sess2": 4, "sess3": 3 },
+  "summary": "Student has asked 12 questions across 3 sessions. Primary focus: procedural. Average hint level: 1.8."
+}
 ```
 
 ---

--- a/app.py
+++ b/app.py
@@ -30,6 +30,8 @@ from models import (
     GenerateReportRequest,
     GenerateReportResponse,
     LabAnalyticsResponse,
+    LogInteractionRequest,
+    LogInteractionResponse,
     PatchReportRequest,
     PostLabCheckRequest,
     PostLabCheckResponse,
@@ -39,6 +41,7 @@ from models import (
     SessionStatus,
     StartSessionRequest,
     StartSessionResponse,
+    StudentContextResponse,
     StudentLabSummary,
     ValidateQuestionRequest,
     ValidateQuestionResponse,
@@ -125,6 +128,9 @@ async def lifespan(app: FastAPI):
     logger.info("Integrity Guardian shut down.")
 
 
+AGENT_NAME = "integrity"
+AGENT_VERSION = "0.1.0"  # tracks the AIEIC interface contract version
+
 app = FastAPI(
     title="AIEIC Integrity Guardian",
     version="2.0.0",
@@ -171,12 +177,22 @@ def get_openai(request: Request) -> AsyncAzureOpenAI:
 
 
 # ---------------------------------------------------------------------------
-# Health endpoint (no auth)
+# Health endpoints (no auth) — match AIEIC interface contract
 # ---------------------------------------------------------------------------
+
+@app.get("/", tags=["health"])
+async def root() -> dict:
+    return {"status": "ok", "agent": AGENT_NAME, "version": AGENT_VERSION}
+
 
 @app.get("/health", tags=["health"])
 async def health_check() -> dict:
-    return {"status": "ok", "timestamp": datetime.utcnow().isoformat() + "Z"}
+    return {
+        "status": "healthy",
+        "agent": AGENT_NAME,
+        "version": AGENT_VERSION,
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -378,6 +394,7 @@ async def validate_question(
         violation=is_violation,
         violation_type=violation_type,
         concept_tags=llm_result.concept_tags,
+        hint_level=llm_result.hint_level,
     )
     session.setdefault("questions", []).append(q_record.model_dump())
 
@@ -399,6 +416,192 @@ async def validate_question(
         violation_count=violation_count,
         question_count=question_count,
         session_escalated=session.get("escalated", False),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Interface Contract endpoints — /integrity/* (used by the Orchestrator)
+# ---------------------------------------------------------------------------
+
+@app.post(
+    "/integrity/log",
+    response_model=LogInteractionResponse,
+    tags=["integrity"],
+    dependencies=[Depends(verify_internal_token)],
+)
+@limiter.limit("60/minute")
+async def log_interaction(
+    request: Request,
+    body: LogInteractionRequest,
+    cosmos: CosmosIntegrityClient = Depends(get_cosmos),
+    openai_client: AsyncAzureOpenAI = Depends(get_openai),
+) -> LogInteractionResponse:
+    """Fire-and-forget interaction log per the AIEIC interface contract.
+
+    Auto-creates the session document on first message so the Orchestrator
+    doesn't need to call /session/start separately. Internally classifies
+    the message and persists violations alongside the interaction.
+    """
+    now_iso = datetime.utcnow().isoformat() + "Z"
+    session = await cosmos.get_session(body.session_id, body.student_id)
+    if session is None:
+        session = SessionDocument(
+            id=body.session_id,
+            student_id=body.student_id,
+            session_id=body.session_id,
+            lab_id=body.lab_id or "unknown",
+            course_id=body.course_id or "CSC580",
+            started_at=now_iso,
+        ).model_dump()
+
+    if session.get("status") == SessionStatus.CLOSED.value:
+        raise HTTPException(status_code=400, detail="Session is already closed.")
+
+    session["question_count"] = session.get("question_count", 0) + 1
+    question_count = session["question_count"]
+    violation_count = session.get("violation_count", 0)
+
+    try:
+        llm_result = await classify_question(
+            question_text=body.message,
+            conversation_history=[],
+            session_context={
+                "lab_id": session.get("lab_id", "unknown"),
+                "question_count": question_count,
+                "violation_count": violation_count,
+            },
+            openai_client=openai_client,
+            deployment_name=settings.AZURE_OPENAI_DEPLOYMENT_NAME,
+        )
+    except RateLimitError:
+        logger.warning("OpenAI rate limit hit during /integrity/log classification.")
+        raise HTTPException(status_code=429, detail="Classification service rate limited.")
+    except Exception as e:
+        logger.error("Classifier error (fail-safe applied): %s", e, exc_info=True)
+        llm_result = ClassificationResult(
+            classification=QuestionClassification.PROCEDURAL,
+            confidence=0.0,
+            reasoning="Classifier unavailable — fail-safe applied.",
+            concept_tags=[],
+        )
+
+    classification = llm_result.classification
+    if classification == QuestionClassification.DIRECT_SOLUTION:
+        is_violation, violation_type, severity = (
+            True, ViolationType.DIRECT_SOLUTION_REQUEST, ViolationSeverity.MAJOR,
+        )
+    elif classification == QuestionClassification.ANSWER_FARMING:
+        is_violation, violation_type, severity = (
+            True, ViolationType.ANSWER_FARMING, ViolationSeverity.MINOR,
+        )
+    else:
+        is_violation, violation_type, severity = False, None, None
+
+    question_id = str(uuid.uuid4())
+    if is_violation and violation_type is not None:
+        violation_count += 1
+        session["violation_count"] = violation_count
+        v_record = ViolationRecord(
+            question_id=question_id,
+            sequence_number=question_count,
+            violation_type=violation_type,
+            severity=severity or ViolationSeverity.MINOR,
+            question_text=body.message,
+        )
+        session.setdefault("violations", []).append(v_record.model_dump())
+        if violation_count >= 3 and not session.get("escalated", False):
+            session["escalated"] = True
+            logger.critical(
+                "INTEGRITY ESCALATION: student=%s session=%s lab=%s "
+                "violation_count=%d last_violation_type=%s",
+                body.student_id, body.session_id, session.get("lab_id"),
+                violation_count, violation_type.value,
+            )
+
+    q_record = QuestionRecord(
+        question_id=question_id,
+        sequence_number=question_count,
+        text=body.message,
+        classification=llm_result.classification,
+        violation=is_violation,
+        violation_type=violation_type,
+        concept_tags=llm_result.concept_tags,
+        hint_level=llm_result.hint_level,
+        response_time_ms=body.response_time_ms,
+    )
+    session.setdefault("questions", []).append(q_record.model_dump())
+    await cosmos.upsert_session(session)
+
+    logger.info(
+        "/integrity/log: student=%s q=%d classification=%s hint=%d violation=%s",
+        body.student_id, question_count, classification.value,
+        int(llm_result.hint_level),
+        violation_type.value if violation_type else "none",
+    )
+    return LogInteractionResponse(status="ok", interaction_id=question_id)
+
+
+@app.get(
+    "/integrity/context/{student_id}",
+    response_model=StudentContextResponse,
+    tags=["integrity"],
+    dependencies=[Depends(verify_internal_token)],
+)
+async def get_student_context(
+    student_id: str,
+    cosmos: CosmosIntegrityClient = Depends(get_cosmos),
+) -> StudentContextResponse:
+    """Aggregated learning profile per the AIEIC interface contract."""
+    sessions = await cosmos.get_all_sessions_for_student(student_id)
+
+    all_questions: list[dict] = []
+    for s in sessions:
+        all_questions.extend(s.get("questions", []))
+
+    total_questions = len(all_questions)
+    sessions_count = len(sessions)
+
+    type_dist: dict[str, int] = {c.value: 0 for c in QuestionClassification}
+    for q in all_questions:
+        cls = q.get("classification")
+        if cls in type_dist:
+            type_dist[cls] += 1
+
+    hint_levels = [
+        int(q["hint_level"]) for q in all_questions
+        if q.get("hint_level") is not None
+    ]
+    avg_hint_level = (sum(hint_levels) / len(hint_levels)) if hint_levels else 0.0
+
+    avg_questions_per_session = (
+        total_questions / sessions_count if sessions_count else 0.0
+    )
+
+    session_help_frequency = {
+        s.get("session_id", s.get("id", "unknown")): s.get("question_count", 0)
+        for s in sessions
+    }
+
+    if type_dist and total_questions:
+        primary_type = max(type_dist, key=lambda k: type_dist[k]).lower()
+    else:
+        primary_type = "n/a"
+    summary = (
+        f"Student has asked {total_questions} question"
+        f"{'s' if total_questions != 1 else ''} across {sessions_count} session"
+        f"{'s' if sessions_count != 1 else ''}. "
+        f"Primary focus: {primary_type}. "
+        f"Average hint level: {avg_hint_level:.1f}."
+    )
+
+    return StudentContextResponse(
+        total_questions=total_questions,
+        question_type_distribution=type_dist,
+        avg_hint_level=avg_hint_level,
+        sessions_count=sessions_count,
+        avg_questions_per_session=round(avg_questions_per_session, 2),
+        session_help_frequency=session_help_frequency,
+        summary=summary,
     )
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ properties:
     ingress:
       allowInsecure: false
       external: false           # Internal only — not publicly exposed
-      targetPort: 8000
+      targetPort: 8001
       transport: Auto
     secrets:
     - name: cosmos-key

--- a/models.py
+++ b/models.py
@@ -29,6 +29,12 @@ class QuestionClassification(str, Enum):
     ANSWER_FARMING = "ANSWER_FARMING"    # incremental pattern assembling full solution
 
 
+class HintLevel(int, Enum):
+    NUDGE = 1          # subtle hint
+    EXPLAIN = 2        # explain the error / concept
+    POINT_TO_DOCS = 3  # point to docs / spec
+
+
 class SessionStatus(str, Enum):
     ACTIVE = "active"
     CLOSED = "closed"
@@ -125,6 +131,35 @@ class PostLabCheckResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Interface Contract — /integrity/* endpoints (matches director's spec)
+# ---------------------------------------------------------------------------
+
+class LogInteractionRequest(BaseModel):
+    student_id: str
+    session_id: str
+    message: str = Field(..., min_length=1, max_length=4000)
+    response_time_ms: Optional[int] = None
+    # Optional extension fields — orchestrator may include them.
+    lab_id: Optional[str] = None
+    course_id: Optional[str] = None
+
+
+class LogInteractionResponse(BaseModel):
+    status: str = "ok"
+    interaction_id: str
+
+
+class StudentContextResponse(BaseModel):
+    total_questions: int
+    question_type_distribution: dict[str, int]
+    avg_hint_level: float
+    sessions_count: int
+    avg_questions_per_session: float
+    session_help_frequency: dict[str, int]
+    summary: str
+
+
+# ---------------------------------------------------------------------------
 # Cosmos DB document models
 # ---------------------------------------------------------------------------
 
@@ -139,6 +174,8 @@ class QuestionRecord(BaseModel):
     violation: bool
     violation_type: Optional[ViolationType] = None
     concept_tags: list[str] = Field(default_factory=list)
+    hint_level: Optional[HintLevel] = None
+    response_time_ms: Optional[int] = None
 
 
 class ViolationRecord(BaseModel):

--- a/policy_engine.py
+++ b/policy_engine.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 
 from openai import AsyncAzureOpenAI
 
-from models import QuestionClassification
+from models import HintLevel, QuestionClassification
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +82,24 @@ ANSWER_FARMING
 5. When in doubt between CONCEPTUAL/PROCEDURAL and DIRECT_SOLUTION/ANSWER_FARMING,
    prefer the non-violation classification unless the evidence is clear.
 
+## Hint Level
+
+In addition to the classification, decide what kind of tutoring response would be most
+appropriate for this question. This guides the Lab Companion toward the right response style:
+
+  1 = NUDGE          subtle hint; the student is on the right track and just needs a small
+                     prompt or a question back. Use for CONCEPTUAL questions where the
+                     student is exploring ideas.
+  2 = EXPLAIN        explain the error, concept, or procedure step-by-step. Use for
+                     PROCEDURAL or debugging-style questions where the student needs a
+                     worked-through walkthrough.
+  3 = POINT_TO_DOCS  direct the student to the lab spec, course notes, or a reference.
+                     Use for CLARIFICATION questions about lab instructions, terminology,
+                     or where to look something up.
+
+For DIRECT_SOLUTION or ANSWER_FARMING, default hint_level to 1 (the appropriate response
+is a redirective nudge rather than the answer).
+
 ## Output Format
 
 Respond with ONLY valid JSON. No markdown, no explanation outside the JSON.
@@ -90,7 +108,8 @@ Respond with ONLY valid JSON. No markdown, no explanation outside the JSON.
   "classification": "CONCEPTUAL|PROCEDURAL|CLARIFICATION|DIRECT_SOLUTION|ANSWER_FARMING",
   "confidence": <float 0.0-1.0>,
   "reasoning": "<1-2 sentence explanation of the classification>",
-  "concept_tags": ["<topic 1>", "<topic 2>"]
+  "concept_tags": ["<topic 1>", "<topic 2>"],
+  "hint_level": 1 | 2 | 3
 }
 
 concept_tags: A list of 1-3 short technical topic labels identifying the concept(s) the
@@ -110,6 +129,7 @@ class ClassificationResult:
     confidence: float
     reasoning: str
     concept_tags: list[str] = field(default_factory=list)
+    hint_level: HintLevel = HintLevel.EXPLAIN
 
 
 # ---------------------------------------------------------------------------
@@ -162,9 +182,29 @@ async def classify_question(
     raw = response.choices[0].message.content
     parsed = json.loads(raw)
 
+    classification = QuestionClassification(parsed["classification"])
+    raw_hint = parsed.get("hint_level")
+    if raw_hint is None:
+        hint_level = _default_hint_level(classification)
+    else:
+        try:
+            hint_level = HintLevel(int(raw_hint))
+        except (ValueError, TypeError):
+            hint_level = _default_hint_level(classification)
+
     return ClassificationResult(
-        classification=QuestionClassification(parsed["classification"]),
+        classification=classification,
         confidence=float(parsed.get("confidence", 1.0)),
         reasoning=parsed.get("reasoning", ""),
         concept_tags=parsed.get("concept_tags", []),
+        hint_level=hint_level,
     )
+
+
+def _default_hint_level(classification: QuestionClassification) -> HintLevel:
+    """Fallback mapping when the LLM doesn't return a parseable hint_level."""
+    if classification == QuestionClassification.CONCEPTUAL:
+        return HintLevel.NUDGE
+    if classification == QuestionClassification.CLARIFICATION:
+        return HintLevel.POINT_TO_DOCS
+    return HintLevel.EXPLAIN

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -35,16 +35,27 @@ def _make_openai_mock():
     return client
 
 
+## ---------------------------------------------------------------------------
+# GET / and GET /health — AIEIC interface contract shape
 # ---------------------------------------------------------------------------
-# GET /health
-# ---------------------------------------------------------------------------
+
+def test_root_endpoint():
+    with TestClient(app) as c:
+        r = c.get("/")
+        assert r.status_code == 200
+        body = r.json()
+        assert body == {"status": "ok", "agent": "integrity", "version": "0.1.0"}
+
 
 def test_health_check():
     with TestClient(app) as c:
         r = c.get("/health")
         assert r.status_code == 200
-        assert r.json()["status"] == "ok"
-        assert "timestamp" in r.json()
+        body = r.json()
+        assert body["status"] == "healthy"
+        assert body["agent"] == "integrity"
+        assert body["version"] == "0.1.0"
+        assert "timestamp" in body
 
 
 def test_health_requires_no_auth():
@@ -282,4 +293,146 @@ def test_lab_analytics_course_id_filter():
 def test_lab_analytics_requires_auth():
     with TestClient(app) as c:
         r = c.get("/analytics/lab/lab01", headers={"X-Internal-Token": "wrong"})
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /integrity/log — AIEIC interface contract endpoint
+# ---------------------------------------------------------------------------
+
+def test_integrity_log_auto_creates_session():
+    """First log call for an unknown session creates the session document."""
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        session_id = str(uuid.uuid4())
+
+        r = c.post("/integrity/log", json={
+            "student_id": "alex_m",
+            "session_id": session_id,
+            "message": "What does impedance matching mean?",
+            "response_time_ms": 1234,
+            "lab_id": "lab4",
+            "course_id": "CSC580",
+        }, headers=HEADERS)
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "ok"
+        assert isinstance(body["interaction_id"], str)
+        # Session is now retrievable
+        s = c.get(f"/session/{session_id}", params={"student_id": "alex_m"}, headers=HEADERS)
+        assert s.status_code == 200
+        assert s.json()["question_count"] == 1
+        assert s.json()["lab_id"] == "lab4"
+
+
+def test_integrity_log_appends_to_existing_session():
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        session_id = str(uuid.uuid4())
+        c.post("/session/start", json={
+            "student_id": "alex_m", "session_id": session_id,
+            "lab_id": "lab4", "course_id": "CSC580",
+        }, headers=HEADERS)
+
+        for msg in ["q1", "q2", "q3"]:
+            r = c.post("/integrity/log", json={
+                "student_id": "alex_m",
+                "session_id": session_id,
+                "message": msg,
+            }, headers=HEADERS)
+            assert r.status_code == 200
+
+        s = c.get(f"/session/{session_id}", params={"student_id": "alex_m"}, headers=HEADERS)
+        assert s.json()["question_count"] == 3
+        assert len(s.json()["questions"]) == 3
+        # hint_level was persisted on each question
+        for q in s.json()["questions"]:
+            assert q["hint_level"] in (1, 2, 3)
+
+
+def test_integrity_log_rejects_closed_session():
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        session_id = str(uuid.uuid4())
+        c.post("/session/start", json={
+            "student_id": "alex_m", "session_id": session_id,
+            "lab_id": "lab4", "course_id": "CSC580",
+        }, headers=HEADERS)
+        c.post("/session/end", json={
+            "student_id": "alex_m", "session_id": session_id,
+        }, headers=HEADERS)
+
+        r = c.post("/integrity/log", json={
+            "student_id": "alex_m", "session_id": session_id, "message": "hi",
+        }, headers=HEADERS)
+        assert r.status_code == 400
+
+
+def test_integrity_log_requires_auth():
+    with TestClient(app) as c:
+        r = c.post("/integrity/log", json={
+            "student_id": "alex_m",
+            "session_id": str(uuid.uuid4()),
+            "message": "hi",
+        }, headers={"X-Internal-Token": "wrong"})
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /integrity/context/{student_id} — AIEIC interface contract endpoint
+# ---------------------------------------------------------------------------
+
+def test_integrity_context_empty_student():
+    with TestClient(app) as c:
+        r = c.get("/integrity/context/no-such-student", headers=HEADERS)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total_questions"] == 0
+        assert body["sessions_count"] == 0
+        assert body["avg_hint_level"] == 0.0
+        assert body["avg_questions_per_session"] == 0.0
+        assert body["session_help_frequency"] == {}
+        # All seven contract fields present
+        for field in [
+            "total_questions", "question_type_distribution", "avg_hint_level",
+            "sessions_count", "avg_questions_per_session", "session_help_frequency",
+            "summary",
+        ]:
+            assert field in body
+
+
+def test_integrity_context_aggregates_across_sessions():
+    with TestClient(app) as c:
+        app.state.openai_client = _make_openai_mock()
+        student_id = f"alex-{uuid.uuid4()}"
+
+        # Two sessions, 3 messages in the first, 2 in the second
+        sid1, sid2 = str(uuid.uuid4()), str(uuid.uuid4())
+        for sid, count in [(sid1, 3), (sid2, 2)]:
+            for i in range(count):
+                c.post("/integrity/log", json={
+                    "student_id": student_id,
+                    "session_id": sid,
+                    "message": f"question {i}",
+                    "lab_id": "lab4",
+                }, headers=HEADERS)
+
+        r = c.get(f"/integrity/context/{student_id}", headers=HEADERS)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total_questions"] == 5
+        assert body["sessions_count"] == 2
+        assert body["avg_questions_per_session"] == 2.5
+        # The mock always returns CONCEPTUAL → hint_level falls back to 1 (NUDGE)
+        assert body["question_type_distribution"]["CONCEPTUAL"] == 5
+        assert body["avg_hint_level"] == 1.0
+        assert body["session_help_frequency"][sid1] == 3
+        assert body["session_help_frequency"][sid2] == 2
+        assert "5 questions across 2 sessions" in body["summary"]
+
+
+def test_integrity_context_requires_auth():
+    with TestClient(app) as c:
+        r = c.get("/integrity/context/alex_m", headers={"X-Internal-Token": "wrong"})
         assert r.status_code == 403


### PR DESCRIPTION
## Summary

Aligns the integrity agent with the director's `INTERFACE_CONTRACT.md` v0.1. Existing endpoints (`/validate`, `/session/*`, `/report/*`, `/analytics/*`) are untouched.

Naming: contract calls us the "Participant Agent" — pending the rename, this PR uses `/integrity/*` instead of `/participant/*`. If the rename doesn't land, it's a one-line path change.

## Changes

**Port & identity**
- Port 8000 → 8001 (`Dockerfile`, `config.yaml`)
- `GET /` added: `{status: "ok", agent: "integrity", version: "0.1.0"}`
- `GET /health` now returns `{status: "healthy", agent, version, timestamp}`

**New contract endpoints**
- `POST /integrity/log` — fire-and-forget log; auto-creates session if missing, runs existing classification/violation pipeline, returns `{status, interaction_id}`
- `GET /integrity/context/{student_id}` — aggregates sessions into `StudentContextResponse` (total_questions, question_type_distribution, avg_hint_level, sessions_count, avg_questions_per_session, session_help_frequency, summary)
- Both require `X-Internal-Token`

**Schemas (`models.py`)**
- Added `HintLevel`, `LogInteractionRequest`, `LogInteractionResponse`, `StudentContextResponse`
- `QuestionRecord` gained optional `hint_level` and `response_time_ms`

**Classifier (`policy_engine.py`)**
- LLM prompt now also asks for `hint_level`
- Fallback when missing: CONCEPTUAL→1, CLARIFICATION→3, else 2
- `/validate` persists `hint_level` (response shape unchanged)

**Tests**
- Updated `/health` assertion, added `GET /` test
- 7 new tests for `/integrity/log` and `/integrity/context/{student_id}`

**Docs**
- README port + new endpoint sections

## Test plan
- [x] `pytest` — 72 passed (pre-existing `test_guardian_client.py` collection error is unrelated, fails on `main` too)
- [ ] Smoke test against orchestrator once director pushes renamed `aieic-shared`
- [ ] Container build on port 8001